### PR TITLE
Adding Hall's 2018 paper on Causal Graph

### DIFF
--- a/papers.bib
+++ b/papers.bib
@@ -786,6 +786,22 @@ keywords = {text-editing, operation-based}
 
 % 2018
 
+@inproceedings{Hall2018CausalGraph,
+author = {Hall, Aaron and Nelson, Grant and Thiesen, Mike and Woods, Nate},
+title = {The Causal Graph CRDT for Complex Document Structure},
+year = {2018},
+isbn = {9781450357692},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://doi.org/10.1145/3209280.3229110},
+doi = {10.1145/3209280.3229110},
+booktitle = {Proceedings of the ACM Symposium on Document Engineering 2018},
+articleno = {34},
+numpages = {4},
+location = {Halifax, NS, Canada},
+series = {DocEng '18}
+}
+
 @article{Lv2018CAD,
 author = {Lv, Xiao and He, Fazhi and Cheng, Yuan and Wu, Yiqi},
 title = {A novel {CRDT}-based synchronization method for real-time collaborative {CAD} systems},


### PR DESCRIPTION
At DocEng 2018 practitioners from Workiva presented this paper describing a Causal Graph used for complex document structure that they have been and are still using for a commercial application.