### PR TITLE
Add more ECOOP 2023 papers

### DIFF
--- a/papers.bib
+++ b/papers.bib
@@ -23,6 +23,59 @@
 
 % 2023
 
+@InProceedings{Kuessner2023algebraicRDT,
+author = {Kuessner, Christian and Mogk, Ragnar and Wickert, Anna-Katharina and Mezini, Mira},
+title = {Algebraic Replicated Data Types: Programming Secure Local-First Software},
+booktitle = {37th European Conference on Object-Oriented Programming},
+pages = {14:1--14:33},
+series = {ECOOP 2023},
+year = {2023},
+month = jul,
+publisher = {Schloss Dagstuhl},
+doi = {10.4230/LIPIcs.ECOOP.2023.14},
+keywords = {delta-based, state-based, composition, security}
+}
+
+@InProceedings{Haas2023LoRe,
+author = {Haas, Julian and Mogk, Ragnar and Yanakieva, Elena and Bieniusa, Annette and Mezini, Mira},
+title = {{LoRe}: A Programming Model for Verifiably Safe Local-First Software},
+booktitle = {37th European Conference on Object-Oriented Programming},
+pages = {12:1--12:15},
+series = {ECOOP 2023},
+year = {2023},
+month = jul,
+publisher = {Schloss Dagstuhl},
+doi = {10.4230/LIPIcs.ECOOP.2023.12},
+eprint = {2304.07133}
+keywords = {verification, systems, reactive programming}
+}
+
+@InProceedings{DePorre2023VeriFx,
+author = {De Porre, Kevin and Ferreira, Carla and Gonzalez Boix, Elisa},
+title = {{VeriFx}: Correct Replicated Data Types for the Masses},
+booktitle = {37th European Conference on Object-Oriented Programming},
+pages = {9:1--9:45},
+series = {ECOOP 2023},
+year = {2023},
+month = jul,
+publisher = {Schloss Dagstuhl},
+doi = {10.4230/LIPIcs.ECOOP.2023.9},
+keywords = {verification, state-based, delta-based, operation-based, pure operation-based}
+}
+
+@InProceedings{BauwensNestedPureOpCRDTs,
+author = {Bauwens, Jim and Gonzalez Boix, Elisa},
+title = {Nested Pure Operation-Based {CRDTs}},
+booktitle = {37th European Conference on Object-Oriented Programming},
+pages = {2:1--2:26},
+series = {ECOOP 2023},
+year = {2023},
+month = jul,
+publisher = {Schloss Dagstuhl},
+doi = {10.4230/LIPIcs.ECOOP.2023.2},
+keywords = {composition, pure operation-based}
+}
+
 @article{Lavoie2023bftlog,
 title = {{2P-BFT-Log}: 2-Phase Single-Author Append-Only Log for Adversarial Environments}, 
 author = {Lavoie, Erick},

--- a/papers.bib
+++ b/papers.bib
@@ -60,6 +60,7 @@ year = {2023},
 month = jul,
 publisher = {Schloss Dagstuhl},
 doi = {10.4230/LIPIcs.ECOOP.2023.9},
+eprint = {2207.02502},
 keywords = {verification, state-based, delta-based, operation-based, pure operation-based}
 }
 
@@ -335,16 +336,6 @@ publisher = {ACM},
 doi = {10.1145/3563901},
 pdf = {https://martin.kleppmann.com/papers/convergence-cacm.pdf},
 keywords = {introduction, crdt-related}
-}
-
-@article{DePorre2022VeriFx,
-author = {De Porre, Kevin and Ferreira, Carla and Gonzalez Boix, Elisa},
-title = {{VeriFx}: Correct Replicated Data Types for the Masses},
-year = {2022},
-month = jul,
-eprint = {2207.02502},
-url = {https://arxiv.org/abs/2207.02502},
-keywords = {verification}
 }
 
 @inproceedings{Soundarapandian2022MRDT,


### PR DESCRIPTION
This PR adds the 4 remaining CRDT related papers from ECOOP 2023.

( @jimbauwens and @kevin-dp might want to check the keywords )

Note that I also merged the existing VeriFx pre-print entry into the newly added VeriFx ECOOP paper entry.