### PR TITLE
Replace LoRe paper with journal version

### DIFF
--- a/papers.bib
+++ b/papers.bib
@@ -21,6 +21,30 @@
 
 % Records in this file are sorted in reverse chronological order (newest first)
 
+% 2024
+
+@article{Haas2024LoRe,
+author     = {Haas, Julian and Mogk, Ragnar and Yanakieva, Elena and Bieniusa, Annette and Mezini, Mira},
+title      = {{LoRe}: A Programming Model for Verifiably Safe Local-First Software},
+year       = {2024},
+issue_date = {March 2024},
+publisher  = {ACM},
+address    = {New York, NY, USA},
+volume     = {46},
+number     = {1},
+issn       = {0164-0925},
+url        = {https://doi.org/10.1145/3633769},
+pdf        = {https://dl.acm.org/doi/pdf/10.1145/3633769},
+doi        = {10.1145/3633769},
+eprint     = {2304.07133},
+journal    = {ACM Transactions on Programming Languages and Systems},
+month      = {jan},
+articleno  = {2},
+numpages   = {26},
+keywords   = {verification, computation, invariants, systems, reactive programming, mixed-consistency}
+}
+
+
 % 2023
 
 @inproceedings{Nasirifard2023orderlessChain,
@@ -100,20 +124,6 @@ month = jul,
 publisher = {Schloss Dagstuhl},
 doi = {10.4230/LIPIcs.ECOOP.2023.14},
 keywords = {delta-based, state-based, composition, security}
-}
-
-@inproceedings{Haas2023LoRe,
-author = {Haas, Julian and Mogk, Ragnar and Yanakieva, Elena and Bieniusa, Annette and Mezini, Mira},
-title = {{LoRe}: A Programming Model for Verifiably Safe Local-First Software},
-booktitle = {37th European Conference on Object-Oriented Programming},
-pages = {12:1--12:15},
-series = {ECOOP 2023},
-year = {2023},
-month = jul,
-publisher = {Schloss Dagstuhl},
-doi = {10.4230/LIPIcs.ECOOP.2023.12},
-eprint = {2304.07133},
-keywords = {verification, systems, reactive programming}
 }
 
 @inproceedings{DePorre2023VeriFx,


### PR DESCRIPTION
The (extended) journal version of the LoRe paper supersedes the previous ECOOP version. This version is open access (like the previous), so no reason to keep the old one.