### PR TITLE
Add list CRDT implementation: Eips

### DIFF
--- a/pages/implementations.md
+++ b/pages/implementations.md
@@ -94,6 +94,10 @@ collaborative applications and replicated storage systems:
 
 * [Loro](https://loro.dev) is a CRDTs library based on [Replayable Event Graph](https://loro.dev/docs/advanced/replayable_event_graph), supporting rich text, list, map, and movable tree. It's implemented in Rust with bindings to JavaScript.
 
+* [Eips](https://github.com/taylordotfish/eips) is a list CRDT with worst-case
+  logarithmic-time operations, support for moving elements, and no interleaving
+  issues. Implemented in Rust.
+
 ## Byzantine fault tolerant CRDT libraries
 
 * [Hyper Hyper Space](https://www.hyperhyperspace.org/) ([GitHub](https://github.com/hyperhyperspace/hyperhyperspace-core/), [Demo](https://hyperhyper.space)) A secure append-only distributed data layer, using Merkle-ized operational CRDTs for mutability.


### PR DESCRIPTION
[Eips](https://github.com/taylordotfish/eips) is a new, free and open source implementation of a list CRDT (for elements of any type) written in Rust. A key feature of Eips is that all operations run in worst-case non-amortized logarithmic time, ensuring low latency for real-time editing applications. It also supports true move operations that don't risk duplicating elements, and does not suffer from interleaving issues (its correctness in this regard is similar to [Fugue](https://arxiv.org/abs/2305.00583)).