### PR TITLE
Add paper "A Local-First Collaborative Modeling Approach with Replicated Data Types"

### DIFF
--- a/papers.bib
+++ b/papers.bib
@@ -23,6 +23,21 @@
 
 % 2025
 
+@inproceedings{Olivier2025modeling,
+title = {{A Local-First Collaborative Modeling Approach with Replicated Data Types}},
+author = {Olivier, L{\'e}o and Morcos, Kirollos and Didonet del Fabro, Marcos and Gerard, Sebastien},
+year = 2025,
+month = {Oct},
+booktitle = {{IEEE conference companion proceedings (MODELS-C). CoPaMo 2025 workshop}},
+address = {Grand Rapids, United States},
+series = {IEEE conference companion proceedings (MODELS-C). CoPaMo 2025 workshop},
+url = {https://cea.hal.science/cea-05322894},
+keywords = {Collaborative modeling ; Conflict-free replicated data types ; Local-First software ; Model-driven engineering},
+pdf = {https://cea.hal.science/cea-05322894v1/file/2025_Copamo_colaborative_modeling.pdf},
+hal_id = {cea-05322894},
+hal_version = {v1}
+}
+
 @article{https://doi.org/10.1002/spe.3430,
 author = {De Porre, Kevin and Ferreira, Carla and Gonzalez Boix, Elisa},
 title = {Concurrency Contracts for Designing Highly Available Replicated Data Types},


### PR DESCRIPTION
Add paper "A Local-First Collaborative Modeling Approach with Replicated Data Types"

- Léo Olivier, Kirollos Morcos, Marcos Didonet del Fabro, Sebastien Gerard. A Local-First Collaborative Modeling Approach with Replicated Data Types. CoPaMo'25 - International Workshop on Collaborative and Participatory Modeling, Oct 2025, Grand Rapids, United States. ⟨cea-05322894⟩