### PR TITLE
Add crdt-merge: CRDT-based merge for AI model weights and datasets

### DIFF
--- a/pages/implementations.md
+++ b/pages/implementations.md
@@ -98,6 +98,13 @@ collaborative applications and replicated storage systems:
   logarithmic-time operations, support for moving elements, and no interleaving
   issues. Implemented in Rust.
 
+
+* [crdt-merge](https://github.com/mgillr/crdt-merge) applies CRDT theory
+  (specifically OR-Set with Merkle hash verification) to AI model weight merging,
+  dataset deduplication, and agent memory. Implemented in Python with zero
+  dependencies. Supports streaming merge, schema evolution, and provenance
+  tracking with 2,118 tests and mathematical correctness proofs. Patent pending.
+
 ## Byzantine fault tolerant CRDT libraries
 
 * [Hyper Hyper Space](https://www.hyperhyperspace.org/) ([GitHub](https://github.com/hyperhyperspace/hyperhyperspace-core/), [Demo](https://hyperhyper.space)) A secure append-only distributed data layer, using Merkle-ized operational CRDTs for mutability.


### PR DESCRIPTION
Hi Martin,

I'd like to add [crdt-merge](https://github.com/mgillr/crdt-merge) to the implementations list.

**What it does**: Applies CRDT theory (specifically OR-Set with Merkle hash verification) to neural network parameter merging, dataset deduplication, and agent memory. It's the first library to bring mathematical correctness guarantees (convergence, commutativity, associativity, idempotence) to model merging.

**Key details**:
- Python, zero-dependency core
- OR-Set CRDT with version vectors and tombstone management
- Merkle hash trees for integrity verification
- Supports safetensors, HuggingFace Hub, Flower federated learning
- 2,118 tests including formal property verification
- BSL-1.1 license (converts to Apache 2.0 in 2028)

**Architecture doc**: https://github.com/mgillr/crdt-merge/blob/main/docs/CRDT_ARCHITECTURE.md

This extends CRDTs into a new domain (ML/AI model weights) where conflict-free merging has been an unsolved problem — existing tools like mergekit lack convergence guarantees.

Thank you for maintaining this wonderful resource!